### PR TITLE
Don't show boost stats

### DIFF
--- a/content/blocks/drills/mechanical-drill.json
+++ b/content/blocks/drills/mechanical-drill.json
@@ -6,6 +6,8 @@ consumes:{
     booster:false
   }
 }
+drillTime:234
+liquidBoostIntensity:1
 requirements:[
   stone/20
   copper/10

--- a/content/blocks/drills/pneumatic-drill.json
+++ b/content/blocks/drills/pneumatic-drill.json
@@ -6,6 +6,8 @@ consumes:{
     booster:false
   }
 }
+drillTime:156
+liquidBoostIntensity:1
 requirements:[
   stone/20
   copper/20


### PR DESCRIPTION
This hide the non-applicable `"Optional Enhancement`" in the info page for the drills.

Outdated screenshot Before/After
![out](https://user-images.githubusercontent.com/4752645/82819552-212b5f00-9ed3-11ea-8268-693aecb25548.png)
